### PR TITLE
Update RSE Team training info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 _site/
 .jekyll-metadata
 .sass-cache/
+vendor/*

--- a/_data/links/RSE_Courses.yml
+++ b/_data/links/RSE_Courses.yml
@@ -6,7 +6,6 @@ tableData:
   level: Core
   topic: 
     - Data
-    - ML
   provider: Sheffield-RSE
   ppt: https://annakrystalli.me/rrresearchACCE20/
   git: https://github.com/annakrystalli/rrresearchACCE20

--- a/_data/links/RSE_Courses.yml
+++ b/_data/links/RSE_Courses.yml
@@ -6,8 +6,6 @@ tableData:
   level: Core
   topic: 
     - Data
-    - R
-    - Version Control
   provider: Sheffield-RSE
   ppt: https://annakrystalli.me/rrresearchACCE20/
   git: https://github.com/annakrystalli/rrresearchACCE20
@@ -18,9 +16,6 @@ tableData:
   level: Core
   topic: 
     - Data
-    - Deep Learning
-    - Regression and Classification
-    - Convolutional Neural Networks
   provider: Sheffield-RSE
   url: https://rse.shef.ac.uk/
   ppt: https://rses-dl-course.github.io/
@@ -44,10 +39,6 @@ tableData:
   level: Core
   topic: 
     - OSS
-    - git 
-    - GitHub
-    - Gitkraken
-    - Version Control
   provider: Sheffield-RSE
   url: https://rse.shef.ac.uk/
   ppt: https://srse-git-github-zero2hero.netlify.app/
@@ -58,10 +49,7 @@ tableData:
   pageName: training.md
   level: Intermediate
   topic: 
-    - Python
-    - Documentation
-    - Software testing
-    - Unit tests
+    - Data
   provider: Sheffield-RSE
   ppt: https://rse.shef.ac.uk/software_engineering_best_practices/
   git: https://github.com/RSE-Sheffield/software_engineering_best_practices

--- a/_data/links/RSE_Courses.yml
+++ b/_data/links/RSE_Courses.yml
@@ -6,6 +6,8 @@ tableData:
   level: Core
   topic: 
     - Data
+    - R
+    - Version Control
   provider: Sheffield-RSE
   ppt: https://annakrystalli.me/rrresearchACCE20/
   git: https://github.com/annakrystalli/rrresearchACCE20
@@ -16,7 +18,9 @@ tableData:
   level: Core
   topic: 
     - Data
-    - ML
+    - Deep Learning
+    - Regression and Classification
+    - Convolutional Neural Networks
   provider: Sheffield-RSE
   url: https://rse.shef.ac.uk/
   ppt: https://rses-dl-course.github.io/

--- a/_data/links/RSE_Courses.yml
+++ b/_data/links/RSE_Courses.yml
@@ -6,6 +6,7 @@ tableData:
   level: Core
   topic: 
     - Data
+    - ML
   provider: Sheffield-RSE
   ppt: https://annakrystalli.me/rrresearchACCE20/
   git: https://github.com/annakrystalli/rrresearchACCE20

--- a/_data/links/RSE_Courses.yml
+++ b/_data/links/RSE_Courses.yml
@@ -40,6 +40,8 @@ tableData:
   level: Core
   topic: 
     - OSS
+    - Git
+    - VC
   provider: Sheffield-RSE
   url: https://rse.shef.ac.uk/
   ppt: https://srse-git-github-zero2hero.netlify.app/

--- a/_data/links/RSE_Courses.yml
+++ b/_data/links/RSE_Courses.yml
@@ -1,13 +1,14 @@
 tableData:
 
 - title: Reproducible Research Data and Project Management in R
-  description: This course focuses on data and project management through R and Rstudio, will introduce students to best practice and equip them with modern tools and techniques for managing data and computational workflows to their full potential. The course is designed to be relevant to students with a wide range of backgrounds, working with anything from relatively small sets of data collected from field or experimental observations, to those taking a more computational approach and bigger datasets.
+  description: This course is not routinely scheduled and is run by arrangement. It focuses on data and project management through R and Rstudio, will introduce students to best practice and equip them with modern tools and techniques for managing data and computational workflows to their full potential. The course is designed to be relevant to students with a wide range of backgrounds, working with anything from relatively small sets of data collected from field or experimental observations, to those taking a more computational approach and bigger datasets.
   pageName: training.md
   level: Core
   topic: 
     - Data
   provider: Sheffield-RSE
-  url: https://annakrystalli.me/rrresearchACCE20/
+  ppt: https://annakrystalli.me/rrresearchACCE20/
+  git: https://github.com/annakrystalli/rrresearchACCE20
 
 - title: Introduction to Deep Learning
   description: In this full-day introductory workshop, you’ll learn the basics of deep learning by training and deploying neural networks with Python or R.
@@ -17,10 +18,12 @@ tableData:
     - Data
     - ML
   provider: Sheffield-RSE
-  url: https://rses-dl-course.github.io/
+  url: https://rse.shef.ac.uk/
+  ppt: https://rses-dl-course.github.io/
+  git: https://github.com/rses-dl-course/rses-dl-course.github.io
 
 - title: Contributing to Open Source Software
-  description: An introduction to open source and Hackoberfest. Using GitHub to explore and contribute to open-source projects with some hands-on tutorials using either the RStudio or GitKraken interfaces or command line git. Prerequisite skills include - Basic git / GitHub use via RStudio, GitKraken or command line.
+  description: This course is run occasionally, usually once a year for Hacktoberfest - an introduction to open source and Hackoberfest. Using GitHub to explore and contribute to open-source projects with some hands-on tutorials using either the RStudio or GitKraken interfaces or command line git. Prerequisite skills include - Basic git / GitHub use via RStudio, GitKraken or command line.
   pageName: training.md
   level: Intermediate
   topic: 
@@ -28,7 +31,8 @@ tableData:
     - Git 
     - VC
   provider: Sheffield-RSE
-  url: https://rse-shef-hacktoberfest-2020.netlify.app
+  ppt: https://rse-shef-hacktoberfest-2020.netlify.app
+  git: https://github.com/RSE-Sheffield/hacktoberfest2020
 
 - title: git & GitHub through GitKraken - from Zero to Hero!
   description: A training course to learn version control and collaboration through Git, GitHub & GitKraken Client.
@@ -36,16 +40,24 @@ tableData:
   level: Core
   topic: 
     - OSS
-    - Git 
-    - VC
+    - git 
+    - GitHub
+    - Gitkraken
+    - Version Control
   provider: Sheffield-RSE
-  url: https://srse-git-github-zero2hero.netlify.app/
+  url: https://rse.shef.ac.uk/
+  ppt: https://srse-git-github-zero2hero.netlify.app/
+  git: https://github.com/RSE-Sheffield/git-github-zero-to-hero
 
 - title: Write better research software (in Python)
   description: A training course to help you write better Python software including docstring documentation and tests with pytest.
   pageName: training.md
   level: Intermediate
   topic: 
-    - Data
+    - Python
+    - Documentation
+    - Software testing
+    - Unit tests
   provider: Sheffield-RSE
-  url: https://rse.shef.ac.uk/software_engineering_best_practices/
+  ppt: https://rse.shef.ac.uk/software_engineering_best_practices/
+  git: https://github.com/RSE-Sheffield/software_engineering_best_practices

--- a/_data/links/RSE_Courses.yml
+++ b/_data/links/RSE_Courses.yml
@@ -17,6 +17,7 @@ tableData:
   level: Core
   topic: 
     - Data
+    - ML
   provider: Sheffield-RSE
   url: https://rse.shef.ac.uk/
   ppt: https://rses-dl-course.github.io/


### PR DESCRIPTION
Hopefully better. For currently scheduled courses, I've linked the RSE Team hope page which is where folks can see the current dates and link through for signup. Could do deeper links?